### PR TITLE
Fixed issue #2. List Woocommerce template overrides in status page

### DIFF
--- a/src/WooCommerce.php
+++ b/src/WooCommerce.php
@@ -70,6 +70,14 @@ class WooCommerce
         $themeTemplate = $this->locateThemeTemplate($template);
         if (!$themeTemplate) {
             return $template;
+        }else{
+            // return theme filename for status screen
+            if (is_admin() &&
+                !wp_doing_ajax() &&
+                get_current_screen() &&
+                'woocommerce_page_wc-status' === get_current_screen()->id ) {
+                return $themeTemplate;
+            }
         }
 
         // Include directly unless it's a blade file.

--- a/src/WooCommerceServiceProvider.php
+++ b/src/WooCommerceServiceProvider.php
@@ -46,6 +46,7 @@ class WooCommerceServiceProvider extends ServiceProvider
         add_filter('woocommerce_locate_template', [$woocommerce, 'template']);
         add_filter('wc_get_template_part', [$woocommerce, 'template']);
         add_filter('comments_template', [$woocommerce, 'reviewsTemplate'], 11);
+        add_filter('wc_get_template', [$woocommerce, 'template']);
     }
 
     public function bindSetupAction()


### PR DESCRIPTION
Fixed issue. Tested and works properly. Works either with blade files or plain php ones.