### PR TITLE
Prevent Single Post Error

### DIFF
--- a/src/WooCommerce.php
+++ b/src/WooCommerce.php
@@ -51,9 +51,9 @@ class WooCommerce
     /**
      * Support blade templates for the woocommerce comments/reviews.
      */
-    public function reviewsTemplate(string $template): string
+    public function reviewsTemplate(?string $template): ?string
     {
-        if (!$this->isWooCommerceTemplate($template)) {
+        if (!$template || !$this->isWooCommerceTemplate($template)) {
             return $template;
         }
 


### PR DESCRIPTION
Using Sage as Child Theme might not pass a string but null from the parent theme on single posts (where comments are loaded). This allows to fail with null.