### PR TITLE
Support Sage 10 as Child Theme

### DIFF
--- a/src/WooCommerce.php
+++ b/src/WooCommerce.php
@@ -108,7 +108,7 @@ class WooCommerce
     {
         $themeTemplate = WC()->template_path() . str_replace(\WC_ABSPATH . 'templates/', '', $template);
         
-        if(is_child_theme()) {
+        if (is_child_theme()) {
             $themeTemplate = str_replace(get_template_directory(), '', $template);
         }
         

--- a/src/WooCommerce.php
+++ b/src/WooCommerce.php
@@ -107,6 +107,11 @@ class WooCommerce
     protected function locateThemeTemplate(string $template): string
     {
         $themeTemplate = WC()->template_path() . str_replace(\WC_ABSPATH . 'templates/', '', $template);
+        
+        if(is_child_theme()) {
+            $themeTemplate = str_replace(get_template_directory(), '', $template);
+        }
+        
         return locate_template($this->sageFinder->locate($themeTemplate));
     }
 }


### PR DESCRIPTION
If Sage is used as Child Theme, `$template` could be the path to the parent theme instead of the plugin directory. This allows a Child Theme to override the Parent Theme WC files.