### PR TITLE
Let child theme overwrite parent theme templates 

### DIFF
--- a/src/WooCommerce.php
+++ b/src/WooCommerce.php
@@ -108,7 +108,7 @@ class WooCommerce
     {
         $themeTemplate = WC()->template_path() . str_replace(\WC_ABSPATH . 'templates/', '', $template);
         
-        if(is_child_theme()) {
+        if (is_child_theme()) {
             $themeTemplate = str_replace(get_template_directory(), '', $template);
         }
         

--- a/src/WooCommerce.php
+++ b/src/WooCommerce.php
@@ -107,6 +107,11 @@ class WooCommerce
     protected function locateThemeTemplate(string $template): string
     {
         $themeTemplate = WC()->template_path() . str_replace(\WC_ABSPATH . 'templates/', '', $template);
+        
+        if(is_child_theme()) {
+            $themeTemplate = str_replace(get_template_directory(), '', $template);
+        }
+        
         return locate_template($this->sageFinder->locate($themeTemplate));
     }
 }

--- a/src/WooCommerce.php
+++ b/src/WooCommerce.php
@@ -106,12 +106,13 @@ class WooCommerce
      */
     protected function locateThemeTemplate(string $template): string
     {
-        $themeTemplate = WC()->template_path() . str_replace(\WC_ABSPATH . 'templates/', '', $template);
-        
-        if (is_child_theme()) {
-            $themeTemplate = str_replace(get_template_directory(), '', $template);
+       $themeTemplate = str_replace(\WC_ABSPATH . 'templates/', '', $template);
+
+        if (is_child_theme() ) {
+            // Let child theme overwrite parent theme templates
+            $themeTemplate = str_replace(get_template_directory() . '/' . WC()->template_path(), '', $themeTemplate);
         }
-        
-        return locate_template($this->sageFinder->locate($themeTemplate));
+
+        return locate_template($this->sageFinder->locate(WC()->template_path() . $themeTemplate));
     }
 }


### PR DESCRIPTION
Finally let Child theme overwrite plugin templates as well as parent theme templates. As discussed here: https://github.com/generoi/sage-woocommerce/pull/9