### PR TITLE
add empty file for WC template functions overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,10 @@ Publish the required `single-product.blade.php` and `archive-product.blade.php` 
 
     wp acorn vendor:publish --tag="WooCommerce Templates"
 
-Optionally publish a commented out `app/wc-template-hooks.php` file for customizing the WC template hooks.
+Optionally publish a commented out `app/wc-template-hooks.php` file for customizing the WC template hooks or an empty `app/wc-template-hooks.php` file for overriding WC template functions.
 
     wp acorn vendor:publish --tag="WooCommerce Template Hook Overrides"
+    wp acorn vendor:publish --tag="WooCommerce Template Functions Overrides"
 
 By default your theme has now declared WooCommerce support. To add support for specific features, add them to your `app/setup.php`
 

--- a/publishes/app/wc-template-functions.php
+++ b/publishes/app/wc-template-functions.php
@@ -1,0 +1,12 @@
+<?php
+
+/**
+ * WooCommerce Template
+ *
+ * Functions for the templating system.
+ *
+ * @package  WooCommerce\Functions
+ * @version  2.5.0
+ */
+
+defined('ABSPATH') || exit;

--- a/src/WooCommerce.php
+++ b/src/WooCommerce.php
@@ -30,6 +30,14 @@ class WooCommerce
     }
 
     /**
+     * Load template functions overrides file if available in app/ folder of theme.
+     */
+    public function loadThemeTemplateFunctions()
+    {
+        locate_template('app/wc-template-functions.php', true, true);
+    }
+
+    /**
      * Declare theme support.
      */
     public function addThemeSupport(): void

--- a/src/WooCommerceServiceProvider.php
+++ b/src/WooCommerceServiceProvider.php
@@ -25,6 +25,7 @@ class WooCommerceServiceProvider extends ServiceProvider
     {
         if (defined('WC_ABSPATH')) {
             $this->app['woocommerce']->loadThemeTemplateHooks();
+            $this->app['woocommerce']->loadThemeTemplateFunctions();
             $this->bindSetupAction();
             $this->bindFilters();
         }
@@ -36,6 +37,10 @@ class WooCommerceServiceProvider extends ServiceProvider
         $this->publishes([
             __DIR__ . '/../publishes/app/wc-template-hooks.php' => $this->app->path('wc-template-hooks.php'),
         ], 'WooCommerce Template Hook Overrides');
+
+        $this->publishes([
+            __DIR__ . '/../publishes/app/wc-template-functions.php' => $this->app->path('wc-template-functions.php'),
+        ], 'WooCommerce Template Functions Overrides');
     }
 
     public function bindFilters()


### PR DESCRIPTION
I've added an additional empty file in order to include WC template functions overrides