### PR TITLE
Use template name instead of template

### DIFF
--- a/src/WooCommerce.php
+++ b/src/WooCommerce.php
@@ -64,10 +64,10 @@ class WooCommerce
      * Filter a template path, taking into account theme templates and creating
      * blade loaders as needed.
      */
-    public function template(string $template, string $templateName): string
+    public function template(string $template, string $templateName = null): string
     {
         // Locate any matching template within the theme.
-        $themeTemplate = $this->locateThemeTemplate($templateName);
+        $themeTemplate = $this->locateThemeTemplate($templateName ?: $template);
         if (!$themeTemplate) {
             return $template;
         }

--- a/src/WooCommerce.php
+++ b/src/WooCommerce.php
@@ -64,10 +64,10 @@ class WooCommerce
      * Filter a template path, taking into account theme templates and creating
      * blade loaders as needed.
      */
-    public function template(string $template): string
+    public function template(string $template, string $templateName): string
     {
         // Locate any matching template within the theme.
-        $themeTemplate = $this->locateThemeTemplate($template);
+        $themeTemplate = $this->locateThemeTemplate($templateName);
         if (!$themeTemplate) {
             return $template;
         }

--- a/src/WooCommerce.php
+++ b/src/WooCommerce.php
@@ -64,7 +64,7 @@ class WooCommerce
      * Filter a template path, taking into account theme templates and creating
      * blade loaders as needed.
      */
-    public function template(string $template, string $templateName = null): string
+    public function template(string $template, string $templateName = ''): string
     {
         // Locate any matching template within the theme.
         $themeTemplate = $this->locateThemeTemplate($templateName ?: $template);

--- a/src/WooCommerceServiceProvider.php
+++ b/src/WooCommerceServiceProvider.php
@@ -46,6 +46,7 @@ class WooCommerceServiceProvider extends ServiceProvider
         add_filter('woocommerce_locate_template', [$woocommerce, 'template'], 10, 2);
         add_filter('woocommerce_locate_core_template', [$woocommerce, 'template'], 10, 2);
         add_filter('wc_get_template_part', [$woocommerce, 'template']);
+        add_filter('wc_get_template', [$woocommerce, 'template'], 1000);
         add_filter('comments_template', [$woocommerce, 'reviewsTemplate'], 11);
     }
 

--- a/src/WooCommerceServiceProvider.php
+++ b/src/WooCommerceServiceProvider.php
@@ -45,9 +45,8 @@ class WooCommerceServiceProvider extends ServiceProvider
         add_filter('template_include', [$woocommerce, 'templateInclude'], 11);
         add_filter('woocommerce_locate_template', [$woocommerce, 'template'], 10, 2);
         add_filter('woocommerce_locate_core_template', [$woocommerce, 'template'], 10, 2);
-        add_filter('wc_get_template_part', [$woocommerce, 'template'], 10);
+        add_filter('wc_get_template_part', [$woocommerce, 'template']);
         add_filter('comments_template', [$woocommerce, 'reviewsTemplate'], 11);
-        add_filter('wc_get_template', [$woocommerce, 'template'], 1000);
     }
 
     public function bindSetupAction()

--- a/src/WooCommerceServiceProvider.php
+++ b/src/WooCommerceServiceProvider.php
@@ -44,7 +44,8 @@ class WooCommerceServiceProvider extends ServiceProvider
 
         add_filter('template_include', [$woocommerce, 'templateInclude'], 11);
         add_filter('woocommerce_locate_template', [$woocommerce, 'template'], 10, 2);
-        add_filter('wc_get_template_part', [$woocommerce, 'template'], 10, 2);
+        add_filter('woocommerce_locate_core_template', [$woocommerce, 'template'], 10, 2);
+        add_filter('wc_get_template_part', [$woocommerce, 'template'], 10);
         add_filter('comments_template', [$woocommerce, 'reviewsTemplate'], 11);
         add_filter('wc_get_template', [$woocommerce, 'template'], 1000, 2);
     }

--- a/src/WooCommerceServiceProvider.php
+++ b/src/WooCommerceServiceProvider.php
@@ -43,10 +43,10 @@ class WooCommerceServiceProvider extends ServiceProvider
         $woocommerce = $this->app['woocommerce'];
 
         add_filter('template_include', [$woocommerce, 'templateInclude'], 11);
-        add_filter('woocommerce_locate_template', [$woocommerce, 'template']);
-        add_filter('wc_get_template_part', [$woocommerce, 'template']);
+        add_filter('woocommerce_locate_template', [$woocommerce, 'template'], 10, 2);
+        add_filter('wc_get_template_part', [$woocommerce, 'template'], 10, 2);
         add_filter('comments_template', [$woocommerce, 'reviewsTemplate'], 11);
-        add_filter('wc_get_template', [$woocommerce, 'template'], 1000);
+        add_filter('wc_get_template', [$woocommerce, 'template'], 1000, 2);
     }
 
     public function bindSetupAction()

--- a/src/WooCommerceServiceProvider.php
+++ b/src/WooCommerceServiceProvider.php
@@ -47,7 +47,7 @@ class WooCommerceServiceProvider extends ServiceProvider
         add_filter('woocommerce_locate_core_template', [$woocommerce, 'template'], 10, 2);
         add_filter('wc_get_template_part', [$woocommerce, 'template'], 10);
         add_filter('comments_template', [$woocommerce, 'reviewsTemplate'], 11);
-        add_filter('wc_get_template', [$woocommerce, 'template'], 1000, 2);
+        add_filter('wc_get_template', [$woocommerce, 'template'], 1000);
     }
 
     public function bindSetupAction()


### PR DESCRIPTION
Add compatibility with third party plugins with it's own templates. Removes the need for adding plugins one by one via "sage-woocommerce/templates" filter.