### PR TITLE
renames tag-names to avoid spaces in tag name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 vendor
 composer.lock
+.idea/

--- a/README.md
+++ b/README.md
@@ -14,11 +14,11 @@ Add the package to the cached package manifest.
 
 Publish the required `single-product.blade.php` and `archive-product.blade.php` views.
 
-    wp acorn vendor:publish --tag="WooCommerce\ Templates"
+    wp acorn vendor:publish --tag="woocommerce-template-views"
 
 Optionally publish a commented out `app/wc-template-hooks.php` file for customizing the WC template hooks.
 
-    wp acorn vendor:publish --tag="WooCommerce\ Template\ Hook\ Overrides"
+    wp acorn vendor:publish --tag="woocommerce-template-hooks"
 
 By default your theme has now declared WooCommerce support. To add support for specific features, add them to your `app/setup.php`
 

--- a/src/WooCommerceServiceProvider.php
+++ b/src/WooCommerceServiceProvider.php
@@ -31,11 +31,11 @@ class WooCommerceServiceProvider extends ServiceProvider
 
         $this->publishes([
             __DIR__ . '/../publishes/resources/views' => $this->app->resourcePath('views/woocommerce'),
-        ], 'WooCommerce Templates');
+        ], 'woocommerce-template-views');
 
         $this->publishes([
             __DIR__ . '/../publishes/app/wc-template-hooks.php' => $this->app->path('wc-template-hooks.php'),
-        ], 'WooCommerce Template Hook Overrides');
+        ], 'woocommerce-template-hooks');
     }
 
     public function bindFilters()


### PR DESCRIPTION
Hi there, 

As the title state this PR only renames the tag names to avoid having spaces in these - which again fixes the readme which didn't work for me when using:

`wp acorn vendor:publish --tag="WooCommerce\ Templates"` which didn't publish anything.
