### PR TITLE
Fix Acorn 4.x support

### DIFF
--- a/src/WooCommerceServiceProvider.php
+++ b/src/WooCommerceServiceProvider.php
@@ -2,7 +2,7 @@
 
 namespace Genero\Sage\WooCommerce;
 
-use Roots\Acorn\ServiceProvider;
+use Illuminate\Support\ServiceProvider;
 
 class WooCommerceServiceProvider extends ServiceProvider
 {


### PR DESCRIPTION
In https://github.com/roots/acorn/commit/f5394b0e800c16683c519f8f3bbeef5f74aef425 (4.x) the `Roots\Acorn\ServiceProvider::class` is changed to `final` instead of `abstract`. Thus we cannot extend this class in an Acorn package anymore and we need to extend `Illuminate\Support\ServiceProvider` instead.